### PR TITLE
Fix 12/ fix dataset time order

### DIFF
--- a/notebooks/setup.ipynb
+++ b/notebooks/setup.ipynb
@@ -190,12 +190,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Rating filtering"
+    "타임스탬프의 오름차순으로 정렬이 되어있지 않음"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 시간 순 정렬"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.groupby('user_id:token', group_keys=False).apply(lambda x: x.sort_values('timestamp:float'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rating filtering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -244,29 +267,29 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>20</th>\n",
        "      <td>1</td>\n",
-       "      <td>2</td>\n",
+       "      <td>924</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>19</th>\n",
        "      <td>1</td>\n",
-       "      <td>29</td>\n",
+       "      <td>919</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>86</th>\n",
        "      <td>1</td>\n",
-       "      <td>32</td>\n",
+       "      <td>2683</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>61</th>\n",
        "      <td>1</td>\n",
-       "      <td>47</td>\n",
+       "      <td>1584</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>23</th>\n",
        "      <td>1</td>\n",
-       "      <td>50</td>\n",
+       "      <td>1079</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -274,29 +297,29 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000257</th>\n",
+       "      <th>20000140</th>\n",
        "      <td>138493</td>\n",
-       "      <td>68319</td>\n",
+       "      <td>6534</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000258</th>\n",
+       "      <th>20000242</th>\n",
        "      <td>138493</td>\n",
-       "      <td>68954</td>\n",
+       "      <td>53464</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000259</th>\n",
+       "      <th>19999965</th>\n",
        "      <td>138493</td>\n",
-       "      <td>69526</td>\n",
+       "      <td>1275</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000260</th>\n",
+       "      <th>20000154</th>\n",
        "      <td>138493</td>\n",
-       "      <td>69644</td>\n",
+       "      <td>6996</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000261</th>\n",
+       "      <th>19999916</th>\n",
        "      <td>138493</td>\n",
-       "      <td>70286</td>\n",
+       "      <td>405</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -305,22 +328,22 @@
       ],
       "text/plain": [
        "          user_id:token  item_id:token\n",
-       "0                     1              2\n",
-       "1                     1             29\n",
-       "2                     1             32\n",
-       "3                     1             47\n",
-       "4                     1             50\n",
+       "20                    1            924\n",
+       "19                    1            919\n",
+       "86                    1           2683\n",
+       "61                    1           1584\n",
+       "23                    1           1079\n",
        "...                 ...            ...\n",
-       "20000257         138493          68319\n",
-       "20000258         138493          68954\n",
-       "20000259         138493          69526\n",
-       "20000260         138493          69644\n",
-       "20000261         138493          70286\n",
+       "20000140         138493           6534\n",
+       "20000242         138493          53464\n",
+       "19999965         138493           1275\n",
+       "20000154         138493           6996\n",
+       "19999916         138493            405\n",
        "\n",
        "[16486759 rows x 2 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -338,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -377,29 +400,29 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>20</th>\n",
        "      <td>1</td>\n",
-       "      <td>2</td>\n",
+       "      <td>924</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>19</th>\n",
        "      <td>1</td>\n",
-       "      <td>29</td>\n",
+       "      <td>919</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>86</th>\n",
        "      <td>1</td>\n",
-       "      <td>32</td>\n",
+       "      <td>2683</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>61</th>\n",
        "      <td>1</td>\n",
-       "      <td>47</td>\n",
+       "      <td>1584</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>23</th>\n",
        "      <td>1</td>\n",
-       "      <td>50</td>\n",
+       "      <td>1079</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -407,29 +430,29 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000257</th>\n",
+       "      <th>20000140</th>\n",
        "      <td>138493</td>\n",
-       "      <td>68319</td>\n",
+       "      <td>6534</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000258</th>\n",
+       "      <th>20000242</th>\n",
        "      <td>138493</td>\n",
-       "      <td>68954</td>\n",
+       "      <td>53464</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000259</th>\n",
+       "      <th>19999965</th>\n",
        "      <td>138493</td>\n",
-       "      <td>69526</td>\n",
+       "      <td>1275</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000260</th>\n",
+       "      <th>20000154</th>\n",
        "      <td>138493</td>\n",
-       "      <td>69644</td>\n",
+       "      <td>6996</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000261</th>\n",
+       "      <th>19999916</th>\n",
        "      <td>138493</td>\n",
-       "      <td>70286</td>\n",
+       "      <td>405</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -438,22 +461,22 @@
       ],
       "text/plain": [
        "          user_id  item_id\n",
-       "0               1        2\n",
-       "1               1       29\n",
-       "2               1       32\n",
-       "3               1       47\n",
-       "4               1       50\n",
+       "20              1      924\n",
+       "19              1      919\n",
+       "86              1     2683\n",
+       "61              1     1584\n",
+       "23              1     1079\n",
        "...           ...      ...\n",
-       "20000257   138493    68319\n",
-       "20000258   138493    68954\n",
-       "20000259   138493    69526\n",
-       "20000260   138493    69644\n",
-       "20000261   138493    70286\n",
+       "20000140   138493     6534\n",
+       "20000242   138493    53464\n",
+       "19999965   138493     1275\n",
+       "20000154   138493     6996\n",
+       "19999916   138493      405\n",
        "\n",
        "[16486759 rows x 2 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -464,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +504,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -499,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -525,7 +548,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -543,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -560,7 +583,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -578,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -608,29 +631,29 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>20</th>\n",
        "      <td>1</td>\n",
-       "      <td>2</td>\n",
+       "      <td>924</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>19</th>\n",
        "      <td>1</td>\n",
-       "      <td>29</td>\n",
+       "      <td>919</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>86</th>\n",
        "      <td>1</td>\n",
-       "      <td>32</td>\n",
+       "      <td>2683</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>61</th>\n",
        "      <td>1</td>\n",
-       "      <td>47</td>\n",
+       "      <td>1584</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>23</th>\n",
        "      <td>1</td>\n",
-       "      <td>50</td>\n",
+       "      <td>1079</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -638,29 +661,29 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000257</th>\n",
+       "      <th>20000140</th>\n",
        "      <td>138493</td>\n",
-       "      <td>68319</td>\n",
+       "      <td>6534</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000258</th>\n",
+       "      <th>20000242</th>\n",
        "      <td>138493</td>\n",
-       "      <td>68954</td>\n",
+       "      <td>53464</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000259</th>\n",
+       "      <th>19999965</th>\n",
        "      <td>138493</td>\n",
-       "      <td>69526</td>\n",
+       "      <td>1275</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000260</th>\n",
+       "      <th>20000154</th>\n",
        "      <td>138493</td>\n",
-       "      <td>69644</td>\n",
+       "      <td>6996</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20000261</th>\n",
+       "      <th>19999916</th>\n",
        "      <td>138493</td>\n",
-       "      <td>70286</td>\n",
+       "      <td>405</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -669,22 +692,22 @@
       ],
       "text/plain": [
        "          user_id  item_id\n",
-       "0               1        2\n",
-       "1               1       29\n",
-       "2               1       32\n",
-       "3               1       47\n",
-       "4               1       50\n",
+       "20              1      924\n",
+       "19              1      919\n",
+       "86              1     2683\n",
+       "61              1     1584\n",
+       "23              1     1079\n",
        "...           ...      ...\n",
-       "20000257   138493    68319\n",
-       "20000258   138493    68954\n",
-       "20000259   138493    69526\n",
-       "20000260   138493    69644\n",
-       "20000261   138493    70286\n",
+       "20000140   138493     6534\n",
+       "20000242   138493    53464\n",
+       "19999965   138493     1275\n",
+       "20000154   138493     6996\n",
+       "19999916   138493      405\n",
        "\n",
        "[16480737 rows x 2 columns]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -732,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -751,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -767,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,7 +819,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -838,7 +861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +890,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Overveiw
- 데이터셋에 사용된 ML-20M 데이터를 timestamp를 사용해 오름차순으로 정렬 후 데이터셋을 구성합니다.

## Change Log
- setup.ipynb에서 데이터셋 생성 전 timestamp를 사용해 오름차순으로 인터랙션 정렬

## Issue Tags
- Fixed: #12
